### PR TITLE
Run Governor cluster with Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,15 @@ COPY helpers /governor/helpers
 COPY postgres0.yml /governor/
 COPY pg_hba.conf /governor/
 COPY init.sql /governor/
+COPY docker-entrypoint.sh /
 
 RUN mkdir -p /data/postgres && \
   chown -R postgres /data && \
   chmod 700 /data/postgres && \
-  chown postgres /governor
+  chown postgres /governor && \
+  chmod +x docker-entrypoint.sh
 
+VOLUME  /data/postgres
 WORKDIR /governor
 
-CMD gosu postgres /governor/governor.py
-
+ENTRYPOINT  ["/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ psql0:
     GOVERNOR_ETCD_HOST: etcd:2379
     GOVERNOR_POSTGRESQL_NAME: postgresql1
     GOVERNOR_POSTGRESQL_DATA_DIR: /data/postgres
+    GOVERNOR_POSTGRESQL_READ_ONLY_PORT: 5433
   links:
     - etcd
   volumes:
@@ -24,7 +25,34 @@ psql1:
     GOVERNOR_ETCD_HOST: etcd:2379
     GOVERNOR_POSTGRESQL_NAME: postgresql2
     GOVERNOR_POSTGRESQL_DATA_DIR: /data/postgres
+    GOVERNOR_POSTGRESQL_READ_ONLY_PORT: 5433
   links:
     - etcd
   volumes:
     - "./pg_hba.conf:/governor/pg_hba.conf"
+
+psql2:
+  image: os/govenror:latest
+  restart: always
+  environment:
+    GOVERNOR_ETCD_HOST: etcd:2379
+    GOVERNOR_POSTGRESQL_NAME: postgresql3
+    GOVERNOR_POSTGRESQL_DATA_DIR: /data/postgres
+    GOVERNOR_POSTGRESQL_READ_ONLY_PORT: 5433
+  links:
+    - etcd
+  volumes:
+    - "./pg_hba.conf:/governor/pg_hba.conf"
+
+
+haproxy:
+  image: haproxy:latest
+  volumes:
+    - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
+  ports:
+    - "5432:5432"
+    - "5433:5433"
+  links:
+   - psql0
+   - psql1
+   - psql2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+etcd:
+  image: quay.io/coreos/etcd
+  restart: always
+  command: >
+    -advertise-client-urls="http://0.0.0.0:2379,http://0.0.0.0:4001"
+    -listen-client-urls="http://0.0.0.0:2379,http://0.0.0.0:4001"
+
+psql0:
+  image: os/govenror:latest
+  restart: always
+  environment:
+    GOVERNOR_ETCD_HOST: etcd:2379
+    GOVERNOR_POSTGRESQL_NAME: postgresql1
+    GOVERNOR_POSTGRESQL_DATA_DIR: /data/postgres
+  links:
+    - etcd
+  volumes:
+    - "./pg_hba.conf:/governor/pg_hba.conf"
+
+psql1:
+  image: os/govenror:latest
+  restart: always
+  environment:
+    GOVERNOR_ETCD_HOST: etcd:2379
+    GOVERNOR_POSTGRESQL_NAME: postgresql2
+    GOVERNOR_POSTGRESQL_DATA_DIR: /data/postgres
+  links:
+    - etcd
+  volumes:
+    - "./pg_hba.conf:/governor/pg_hba.conf"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+GOVERNOR_POSTGRESQL_LISTEN=`hostname -I`:5432 exec gosu postgres /governor/governor.py
+
+exec "$@"

--- a/pg_hba.conf
+++ b/pg_hba.conf
@@ -8,7 +8,7 @@ host    all             all             127.0.0.1/32            trust
 host    all             all             ::1/128                 trust
 
 # Replication user
-host replication replicator 10.0.3.1/24 md5
+host replication replicator 172.17.0.0/16 trust
 
 # Application users with md5 password
 host all all 10.0.3.1/24 md5


### PR DESCRIPTION
Hi!

Thanks for adjusting Govenror to run within Docker containers. I've prepared a `docker-compose.yml` file to run Govenror cluster smoothly. I believe any further steps, I mean using either HAProxy, PgPool or whatever, are up to user needs. 

In case of changes:
- I've slightly changed the Dockerfile to run upon `ENTRYPOINT`, because it wraps `GOVERNOR_POSTGRESQL_LISTEN` variable, since it cannot be set in conf file (IP of the container is unknown). It's quite hacky, but I didn't have better idea how to deal with that. 
- I've added `/data/postgres` as `VOLUME` to persist PSQL data.
- `docker-compose.yml` imports `pg_hba.conf` from host, because for some reason the [`write_pg_hba`](https://github.com/miketonks/governor/blob/master/helpers/postgresql.py#L72) function is commented out and so, the `GOVERNOR_POSTGRESQL_REPLICATION_NETWORK` is not used.

If you'd accept the PR, probably `README` should be updated as well.
